### PR TITLE
Update branch alias to match newest 1.x version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.x-dev"
         }
     }
 }


### PR DESCRIPTION
Simliar to phpcr/phpcr-shell the master branch should match the newest 1.x version and not 1.0.x.